### PR TITLE
feat: full project scaffolding now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,28 @@ This package is used to scaffold your sywac-powered CLI project when you run `np
 
 ## Recommended Usage
 
+To create a project from scratch:
+
 ```console
 $ mkdir <project>
 $ cd <project>
 $ git init
 $ git remote add origin <blah>
 $ npm init
+$ npm init sywac --all
+```
+
+To just add sywac to an existing project:
+
+```console
+$ cd <project>
 $ npm init sywac
+```
+
+To see all options:
+
+```console
+$ npm init sywac -- --help
 ```
 
 ## Details
@@ -20,29 +35,29 @@ $ npm init sywac
 This tool sets up the following:
 
 - Makes sure the project directory exists, if specified via `npm init sywac <dir>`
+- Creates an executable `cli.js` file, if missing
 - Creates or modifies a `package.json` file:
   - Adds `sywac` and `sywac-style-basic` as production dependencies, if missing
   - Defines `"bin"` to be `"cli.js"`, if not defined
-  - Defines `"main"` to be `"index.js"`, if not defined
-  - Adds `"cli.js"` and `"index.js"` to `"files"`, if missing
-  - Adds dev dependencies, if missing:
+  - Optionally defines `"main"` to be `"index.js"`, if not defined
+  - Optionally adds `"cli.js"` and `"index.js"` to `"files"`, if missing
+  - Optionally adds dev dependencies, if missing:
     - `coveralls`
     - `standard`
     - `standard-version`
     - `tap`
-  - Adds scripts, if missing:
+  - Optionally adds scripts, if missing:
     - `"pretest": "standard"`
     - `"test": "tap --cov test.js"`
     - `"coverage": "nyc report --reporter=text-lcov | coveralls"`
     - `"release": "standard-version"`
-- Creates an executable `cli.js` file, if missing
-- Creates a default `.gitignore` file, if missing
-- Creates a default `.npmrc` file, if missing
-- Creates a default `.travis.yml` file, if missing
-- Creates a default ISC `LICENSE` file, if missing
-- Creates a default `README.md` file, if missing
-- Creates an empty `index.js` file, if missing
-- Creates an empty `test.js` file, if missing
+- Optionally creates a default `.gitignore` file, if missing
+- Optionally creates a default `.npmrc` file, if missing
+- Optionally creates a default `.travis.yml` file, if missing
+- Optionally creates a default ISC `LICENSE` file, if missing
+- Optionally creates a default `README.md` file, if missing
+- Optionally creates an empty `index.js` file, if missing
+- Optionally creates an empty `test.js` file, if missing
 
 ## License
 

--- a/cli.js
+++ b/cli.js
@@ -2,21 +2,40 @@
 
 const cli = require('sywac')
   .style(require('sywac-style-basic'))
-  .outputSettings({ maxWidth: 65 })
+  .outputSettings({ maxWidth: 63 })
+  .preface(null, [
+    'Create a sywac CLI project in an idempotent way. This will add',
+    'sywac to your project with a default cli.js file. It will touch',
+    'package.json but will not overwrite files that already exist.'
+  ].join('\n'))
   .positional('[dir]', {
     paramsDesc: 'Optional path to project directory'
   })
-  .string('-v, --version <string>', {
+  .boolean('-a, --all', {
+    group: 'Scaffolding Options:',
+    desc: 'Scaffold all basic project files and dev dependencies'
+  })
+  .string('-d, --desc "Some desc"', {
+    group: 'Scaffolding Options:',
+    desc: 'Define project\'s initial description'
+  })
+  .string('-w, --wersion <x.y.z>', { // workaround for `npm init sywac -v x.y.z`
+    group: 'Scaffolding Options:',
     desc: 'Define the project\'s initial version',
     defaultValue: '0.1.0'
   })
   .help('-h, --help', {
-    implicitCommand: false,
-    group: 'Help:'
+    group: 'Help Options:',
+    implicitCommand: false
   })
   .version('-V, --VERSION', {
-    implicitCommand: false,
-    group: 'Help:'
+    group: 'Help Options:',
+    desc: 'Show create-sywac version number',
+    implicitCommand: false
+  })
+  .check((argv, ctx) => {
+    if (argv._.includes('--help') || argv._.includes('-h')) ctx.deferHelp()
+    else argv.version = argv.wersion
   })
 
 module.exports = cli


### PR DESCRIPTION
Support full project scaffolding via `npm init sywac --all`. (This was previously the default behavior.)

Also support just adding sywac to an existing project via `npm init sywac`.

Also fix options that were competing with `npm init` options (`-h`, `--help`, `-v`, `--version`).